### PR TITLE
Remove jQuery from the README as it is no longer configured in resource.index file in SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Finally, include the script *per-user-authentication-matching.js* in the `javasc
 javascript = /resource/script/per-user-authentication-matching.js
 ```
 
+This script uses jQuery library provided by SSO. SSO always include the latest version of jQuery
+
 ## Configuration
 
 Per User Authentication Matching supports a number of configuration parameters, which are defined as properties in a javascript object named `perUserAuthenticationMatchingParams`. The object  can either be inserted on top of the *per-user-authentication-matching.js*, or alternatively in a separate javascript file (see ***Using separate configuration file*** below).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For the following section we'll use the template named *default* to install the 
 
 Check from the template index (*ubilogin/custom/template.index*) which template properties file corresponds to the *default* template. You should be able to locate the line in which the key `default` is defined. The value is the relative location of the template properties file.
 
-If `default` is not set in the template index, then you'll need add it.
+If `default` is not set in the template index, then you'll need to add it.
 ```
 default = templates/default.properties
 ```

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ default = templates/default.properties
 ```
 The corresponding template properties file in this case would be *ubilogin/custom/templates/default.properties*.
 
-Finally include the script *per-user-authentication-matching.js* in the `javascript` property in the template properties as shown below. Also, since Per User Authentication Matching uses jQuery, the script *jquery.js* needs to be present and located **before** *per-user-authentication-matching.js*. The *jquery.js* is provided with SSO so it doesn't need to be defined in the resource index.
+Finally, include the script *per-user-authentication-matching.js* in the `javascript` property in the template properties as shown below.
 ```
-javascript = /resource/script/jquery.js, /resource/script/per-user-authentication-matching.js
+javascript = /resource/script/per-user-authentication-matching.js
 ```
 
 ## Configuration
@@ -173,7 +173,7 @@ script/per-user-authentication-matching-config-default.js = resources/script/per
 ```
 and also in the template properties.
 ```
-javascript = /resource/script/jquery.js, /resource/script/per-user-authentication-matching-config-default.js, /resource/script/per-user-authentication-matching.js
+javascript = /resource/script/per-user-authentication-matching-config-default.js, /resource/script/per-user-authentication-matching.js
 ```
 Note that the configuration file needs to be located before the *per-user-authentication-matching.js* so that the configurations get loaded before the implementation.
 


### PR DESCRIPTION
In upcoming release of SSO, the jQuery script will not be configurable in resource.index file. Therefore, it can be removed from example configuration of `javascript` key of template properties file.